### PR TITLE
Feat: 마이그레이션 data-source 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "typeorm-ts-node-commonjs -d src/data-source.ts"
   },
   "dependencies": {
     "@nestjs/common": "^8.0.0",

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,12 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+export const appDataSource = new DataSource({
+  type: 'postgres',
+  database: 'postgres',
+  entities: ['**/*.entity.ts'],
+  migrations: [__dirname + '/migrations/*.ts'],
+  host: 'localhost',
+  port: 55001,
+  username: 'postgres',
+  password: 'postgrespw',
+} as DataSourceOptions);


### PR DESCRIPTION
마이그레이션을 위해서 data-source 파일을 작성했습니다

현재 테스트는 고려하지 않아서 nest/config는 이용하지 않고 컴팩트하게 했습니다

package에도 typeorm 명령어가 스크립트에 추가되었습니다

entity gernerate 명령어 -> npm run typeorm migration:generate src/migrations/원하는 파일명