### PR TITLE
Fix: datasource 환경변수, 스네이크 케이스 가능하게 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,5 @@ lerna-debug.log*
 # Environment
 .env
 
-# Data-source
-data-source.ts
-
 # Migrations
 /src/migrations

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/typeorm": "^9.0.0",
+        "dotenv": "^16.0.1",
         "pg": "^8.7.3",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/typeorm": "^9.0.0",
+    "dotenv": "^16.0.1",
     "pg": "^8.7.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,16 @@
+import 'dotenv/config';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
+export const appDataSource = new DataSource({
+  type: 'postgres',
+  database: process.env.POSTGRES_DATABASE,
+  entities: ['**/*.entity.ts'],
+  migrations: ['src/migrations/*.ts'],
+  host: process.env.POSTGRES_HOST,
+  port: parseInt(process.env.POSTGRES_PORT, 10),
+  username: process.env.POSTGRES_USERNAME,
+  password: process.env.POSTGRES_PASSWORD,
+  synchronize: false,
+  namingStrategy: new SnakeNamingStrategy(),
+} as DataSourceOptions);


### PR DESCRIPTION
1. datasource 파일에 .env의 환경변수를 설정할 수 있게 했씁니다
2. datasource 파일에 DB를 typeorm이 읽을 때 카멜을 스네이크로 읽을 수 있게 설정했습니다
3. .gitignore에 datasource 삭제했습니다