### PR TITLE
Fix: 토큰 종류 확인

### DIFF
--- a/src/v1/middlewares/validate-info.middleware.ts
+++ b/src/v1/middlewares/validate-info.middleware.ts
@@ -15,7 +15,7 @@ export class ValidateInfoMiddleware implements NestMiddleware {
 
   async use(req: any, res: Response, next: () => void): Promise<void> {
     const jwt = req.headers['authorization'];
-    if (jwt === undefined) {
+    if (jwt === undefined || !jwt.startsWith('Bearer')) {
       return next();
     }
     const user: jwtUser = this.jwtService.verify(jwt.substring(7));


### PR DESCRIPTION
윈도우에서 로그인 시도 시 Basic 토큰이 들어있어서 에러 발생 -> Bearer만 확인하도록 변경